### PR TITLE
테이블 조회에 대한 API 호출 및 DTO 파싱 예제 코드 추가

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     // jackson-databind for ObjectMapper
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/cli/src/main/java/com/pickypal/dto/stock/HeadStockViewResponseDto.java
+++ b/cli/src/main/java/com/pickypal/dto/stock/HeadStockViewResponseDto.java
@@ -1,4 +1,4 @@
-package com.pickypal.dto;
+package com.pickypal.dto.stock;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/cli/src/main/java/com/pickypal/util/ApiKit.java
+++ b/cli/src/main/java/com/pickypal/util/ApiKit.java
@@ -1,22 +1,27 @@
 package com.pickypal.util;
 
-import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 
 /**
  * @author Queue-ri
  */
 
-@Slf4j
 public class ApiKit {
 
     // Http GET request to backend server
-    // **no auth header: 회원가입, 로그인 용도**
+    // **no auth header**
     public ApiResponse getRequest(String endpoint) {
         ApiResponse res = new ApiResponse();
 
@@ -64,13 +69,17 @@ public class ApiKit {
             int statusCode = response.getStatusLine().getStatusCode();
             res.setStatusCode(statusCode);
 
-            // Response 출력
+            // response 출력
             String body;
             if (statusCode == 200) {
-                ResponseHandler<String> handler = new BasicResponseHandler();
-                body = handler.handleResponse(response);
+                // response body를 UTF-8로 파싱
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
+                body = bufferedReader.readLine();
+                bufferedReader.close();
+                
                 System.out.println("* * * ApiKit(auth GET): 200 OK");
                 System.out.println(body);
+
             } else {
                 System.out.println("* * * ApiKit(auth GET): Server returned " + statusCode);
                 body = null;
@@ -85,10 +94,80 @@ public class ApiKit {
         return res;
     }
 
+    // Http POST request to backend server
+    // **no auth header: 로그인, 회원가입 용도**
+    public ApiResponse postRequest(String endpoint, Object dto) {
+        ApiResponse res = new ApiResponse();
+        ObjectMapper mapper = new ObjectMapper();
+
+        try {
+            CloseableHttpClient client = HttpClients.createDefault();
+            HttpPost postRequest = new HttpPost(endpoint); // POST 메소드 URL 생성
+            postRequest.setHeader("Content-Type", "application/json");
+            // add body
+            String json = mapper.writeValueAsString(dto);
+            HttpEntity entity = new ByteArrayEntity(json.getBytes("UTF-8"));
+            postRequest.setEntity(entity);
+
+            CloseableHttpResponse response = client.execute(postRequest);
+            int statusCode = response.getStatusLine().getStatusCode();
+            res.setStatusCode(statusCode);
+
+            // Response 출력
+            String body;
+            if (statusCode == 200) {
+                ResponseHandler<String> handler = new BasicResponseHandler();
+                body = handler.handleResponse(response);
+                System.out.println("* * * ApiKit(POST): 200 OK");
+                System.out.println(body);
+            } else {
+                System.out.println("* * * ApiKit(POST): Server returned " + statusCode);
+                body = null;
+            }
+            res.setJsonStr(body);
+            client.close();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return res;
+    }
+
     // Http POST request **with auth header** to backend server
     // 모든 등록 용도: access token 필요
-    public void postRequestWithAuth(String endpoint) {
+    public ApiResponse postRequestWithAuth(String endpoint) {
+        String ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJyb290Iiwicm9sZSI6IkhFQUQiLCJleHAiOjE3MzU3NDQ0NjN9.4Y6yReg_4HO_66rz5e-7XGrQEux80gxf0RQu9ONG598";
+        ApiResponse res = new ApiResponse();
 
+        try {
+            CloseableHttpClient client = HttpClients.createDefault();
+            HttpPost postRequest = new HttpPost(endpoint); // POST 메소드 URL 생성
+            postRequest.addHeader("Authorization", ACCESS_TOKEN); // token 이용시
+
+            CloseableHttpResponse response = client.execute(postRequest);
+            int statusCode = response.getStatusLine().getStatusCode();
+            res.setStatusCode(statusCode);
+
+            // Response 출력
+            String body;
+            if (statusCode == 200) {
+                ResponseHandler<String> handler = new BasicResponseHandler();
+                body = handler.handleResponse(response);
+                System.out.println("* * * ApiKit(auth POST): 200 OK");
+                System.out.println(body);
+            } else {
+                System.out.println("* * * ApiKit(auth POST): Server returned " + statusCode);
+                body = null;
+            }
+            res.setJsonStr(body);
+            client.close();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return res;
     }
 
     // Http DELETE request **with auth header** to backend server

--- a/cli/src/main/java/com/pickypal/util/ApiKitSample.java
+++ b/cli/src/main/java/com/pickypal/util/ApiKitSample.java
@@ -1,0 +1,55 @@
+package com.pickypal.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pickypal.dto.stock.HeadStockViewResponseDto;
+
+import java.util.List;
+
+/**
+ * @author Queue-ri
+ */
+
+public class ApiKitSample {
+    
+    // ApiKit으로 어떻게 API를 호출하는지 작성한 예제 코드
+    // CLI 프로그램과 무관함
+    public static void main(String[] args) throws JsonProcessingException {
+        ApiKit apiKit = new ApiKit();
+
+        /* 로그인 토큰(auth)을 사용한 HTTP GET 호출
+         * --> 객체 리스트 [{}] 형식의 json이 반환될 때 (ex. 본사 재고 조회 api)
+         */
+        // API 호출
+        int pageIdx = 0;
+        ApiResponse response = apiKit.getRequestWithAuth("http://localhost:8080/head/stock/" + pageIdx);
+
+        int statusCode = response.getStatusCode();
+        System.out.println("* * * ApiKitSample - status code: " + response.getStatusCode());
+
+        if (statusCode == 200) { // 정상 호출되면
+            // json string을 dto 객체의 List로 파싱
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JavaTimeModule()); // LocalDateTime 파싱을 위해 필요
+            String jsonStr = response.getJsonStr();
+            List<HeadStockViewResponseDto> dtoList = mapper.readValue(jsonStr, TypeFactory.defaultInstance().constructCollectionType(List.class, HeadStockViewResponseDto.class));
+
+            System.out.println("* * * ApiKitSample - parsed dto list: ");
+            for (HeadStockViewResponseDto dto : dtoList) {
+                System.out.println(dto.toString()); // 각 column별 값은 dto.getItemName() 처럼 getter로 접근
+            }
+        }
+        else { // 호출 실패하면
+            System.out.println("* * * ApiKitSample: 응 아니야~");
+        }
+
+
+
+        /*  토큰 없이 HTTP POST 호출
+         * --> 단일 객체 {} 형식의 json이 반환될 때 (ex. 로그인 api 호출 후 반환되는 형식)
+         */
+        
+    }
+}


### PR DESCRIPTION
# 중요 예제 코드여서 우선 merge 합니다
- 앞으로 모든 테이블 조회는 이런 형식으로 하시면 됩니다 (`ApiKitSample` 클래스의 `main` 함수 참고)
    - 최종 변환 결과는 DTO 리스트이고, 각 DTO가 한 row(행)를 의미함
    - 각 DTO 별로 getter를 호출해서 멤버변수(column) 값을 가져오면 됨
- 인코딩 버그 패치 완료

![image](https://github.com/user-attachments/assets/a2f51858-03bc-4b54-bc1f-4269957b4a21)
